### PR TITLE
FIX: Mapping of HID usage types for left sticks and RT2 and LT2 is mixed up for PS5 Dualsense

### DIFF
--- a/io-kit-sys/src/hid/usage_tables.rs
+++ b/io-kit-sys/src/hid/usage_tables.rs
@@ -59,10 +59,10 @@ pub const kHIDUsage_GD_MultiAxisController: u32 = 0x08;
 // 0x09 - 0x2F Reserved
 pub const kHIDUsage_GD_X: u32 = 0x30;
 pub const kHIDUsage_GD_Y: u32 = 0x31;
-pub const kHIDUsage_GD_Z: u32 = 0x32;
-pub const kHIDUsage_GD_Rx: u32 = 0x33;
-pub const kHIDUsage_GD_Ry: u32 = 0x34;
-pub const kHIDUsage_GD_Rz: u32 = 0x35;
+pub const kHIDUsage_GD_Z: u32 = 0x34;
+pub const kHIDUsage_GD_Rx: u32 = 0x32;
+pub const kHIDUsage_GD_Ry: u32 = 0x35;
+pub const kHIDUsage_GD_Rz: u32 = 0x33;
 pub const kHIDUsage_GD_Slider: u32 = 0x36;
 pub const kHIDUsage_GD_Dial: u32 = 0x37;
 pub const kHIDUsage_GD_Wheel: u32 = 0x38;


### PR DESCRIPTION
Using the PS5 Dualsense controller I get mixed up readings for the right stick and RT2/LT2. This pull request fixes that. But beware: I only have the PS5 controller to test this and thus am not sure if this might break support for other controllers.

I came across this using bevy 0.9.1 which uses gilrs 0.10.1 which uses io-kit-rs 0.2.0

macos 13.1, Apple Silicon