### PR TITLE
switch mach to mach2

### DIFF
--- a/io-kit-sys/Cargo.toml
+++ b/io-kit-sys/Cargo.toml
@@ -11,4 +11,4 @@ edition = "2018"
 
 [dependencies]
 core-foundation-sys = "0.8.3"
-mach="0.3.2"
+mach2="0.4.1"

--- a/io-kit-sys/src/lib.rs
+++ b/io-kit-sys/src/lib.rs
@@ -3,7 +3,7 @@
 #![allow(non_snake_case)]
 
 extern crate core_foundation_sys;
-extern crate mach;
+extern crate mach2;
 
 pub mod base;
 pub mod keys;
@@ -21,13 +21,13 @@ use core_foundation_sys::base::{CFAllocatorRef, CFTypeRef};
 use core_foundation_sys::dictionary::{CFDictionaryRef, CFMutableDictionaryRef};
 use core_foundation_sys::runloop::CFRunLoopSourceRef;
 use core_foundation_sys::string::CFStringRef;
-use mach::boolean::boolean_t;
-use mach::clock_types::mach_timespec_t;
-use mach::kern_return::kern_return_t;
-use mach::mach_types::task_port_t;
-use mach::message::mach_msg_header_t;
-use mach::port::mach_port_t;
-use mach::vm_types::{mach_vm_address_t, mach_vm_size_t};
+use mach2::boolean::boolean_t;
+use mach2::clock_types::mach_timespec_t;
+use mach2::kern_return::kern_return_t;
+use mach2::mach_types::task_port_t;
+use mach2::message::mach_msg_header_t;
+use mach2::port::mach_port_t;
+use mach2::vm_types::{mach_vm_address_t, mach_vm_size_t};
 
 use base::dispatch_queue_t;
 use ret::IOReturn;

--- a/io-kit-sys/src/ret.rs
+++ b/io-kit-sys/src/ret.rs
@@ -2,7 +2,7 @@
 
 use std::os::raw::c_int;
 
-use mach::kern_return::{kern_return_t, KERN_SUCCESS};
+use mach2::kern_return::{kern_return_t, KERN_SUCCESS};
 
 // sys_iokit
 const SYS_IOKIT: c_int = ((0x38) & 0x3f) << 26;

--- a/io-kit-sys/src/types.rs
+++ b/io-kit-sys/src/types.rs
@@ -2,8 +2,8 @@
 
 use std::os::raw::{c_char, c_int, c_uint, c_ulonglong};
 
-use mach::port::mach_port_t;
-use mach::vm_types::mach_vm_address_t;
+use mach2::port::mach_port_t;
+use mach2::vm_types::mach_vm_address_t;
 
 pub type IOOptionBits = c_uint;
 pub type IOFixed = c_int;

--- a/io-kit/Cargo.toml
+++ b/io-kit/Cargo.toml
@@ -14,4 +14,4 @@ version = "0.2.0"
 
 [dependencies]
 core-foundation = "0.9.3"
-mach="0.3.2"
+mach2="0.4.1"

--- a/io-kit/src/base.rs
+++ b/io-kit/src/base.rs
@@ -8,7 +8,7 @@ use core_foundation::dictionary::CFDictionary;
 use core_foundation::string::CFString;
 use io_kit_sys::types::{io_iterator_t, io_object_t, io_service_t};
 use io_kit_sys::*;
-use mach::kern_return::KERN_SUCCESS;
+use mach2::kern_return::KERN_SUCCESS;
 
 pub struct IOObject(io_object_t);
 

--- a/io-kit/src/lib.rs
+++ b/io-kit/src/lib.rs
@@ -3,7 +3,7 @@
 
 #[macro_use(impl_TCFType)]
 extern crate core_foundation;
-extern crate mach;
+extern crate mach2;
 
 extern crate io_kit_sys;
 


### PR DESCRIPTION
There is a RUSTSEC warning about crate `mach`: https://rustsec.org/advisories/RUSTSEC-2020-0168 as it's unmaintained (https://github.com/fitzgen/mach/issues/63)

This PR switches `mach` to `mach2`