### PR TITLE
Add keys from IOSerialKeys

### DIFF
--- a/io-kit-sys/src/lib.rs
+++ b/io-kit-sys/src/lib.rs
@@ -13,6 +13,7 @@ pub mod types;
 pub mod hid;
 pub mod ps;
 pub mod pwr_mgt;
+pub mod serial;
 pub mod usb;
 
 use std::os::raw::{c_char, c_int, c_void};

--- a/io-kit-sys/src/serial/keys.rs
+++ b/io-kit-sys/src/serial/keys.rs
@@ -1,0 +1,26 @@
+// exports from <IOKit/serial/IOSerialKeys.h>
+
+use ::std::os::raw::c_char;
+
+pub const kIOSerialBSDServiceValue: *const c_char =
+    b"IOSerialBSDClient\0" as *const [u8; 18] as *const c_char;
+pub const kIOSerialBSDTypeKey: *const c_char =
+    b"IOSerialBSDClientType\0" as *const [u8; 22] as *const c_char;
+pub const kIOSerialBSDAllTypes: *const c_char =
+    b"IOSerialStream\0" as *const [u8; 15] as *const c_char;
+pub const kIOSerialBSDModemType: *const c_char =
+    b"IOSerialStream\0" as *const [u8; 15] as *const c_char;
+pub const kIOSerialBSDRS232Type: *const c_char =
+    b"IOSerialStream\0" as *const [u8; 15] as *const c_char;
+pub const kIOTTYDeviceKey: *const c_char =
+    b"IOTTYDevice\0" as *const [u8; 12] as *const c_char;
+pub const kIOTTYBaseNameKey: *const c_char =
+    b"IOTTYBaseName\0" as *const [u8; 14] as *const c_char;
+pub const kIOTTYSuffixKey: *const c_char =
+    b"IOTTYSuffix\0" as *const [u8; 12] as *const c_char;
+pub const kIOCalloutDeviceKey: *const c_char =
+    b"IOCalloutDevice\0" as *const [u8; 16] as *const c_char;
+pub const kIODialinDeviceKey: *const c_char =
+    b"IODialinDevice\0" as *const [u8; 15] as *const c_char;
+pub const kIOTTYWaitForIdleKey: *const c_char =
+    b"IOTTYWaitForIdle\0" as *const [u8; 17] as *const c_char;

--- a/io-kit-sys/src/serial/mod.rs
+++ b/io-kit-sys/src/serial/mod.rs
@@ -1,0 +1,1 @@
+pub mod keys;


### PR DESCRIPTION
This PR adds the keys from IOKit's `serial/IOSerialkeys.h`. These keys are used for example for enumerating serial devices.