### PR TITLE
Use mem::MaybeUninit instead of mem::uninitialized() (which has been deprecated)

### DIFF
--- a/io-kit/src/base.rs
+++ b/io-kit/src/base.rs
@@ -100,17 +100,19 @@ impl IOService {
 
     pub fn get_matching_services(matching: CFDictionary) -> Result<Vec<Self>, i32> {
         unsafe {
-            let mut io_iterator_t: io_iterator_t = mem::uninitialized();
+            let mut io_iterator_t = mem::MaybeUninit::<io_iterator_t>::uninit();
 
             let result = IOServiceGetMatchingServices(
                 kIOMasterPortDefault,
                 matching.as_CFTypeRef() as _,
-                &mut io_iterator_t,
+                io_iterator_t.as_mut_ptr(),
             );
 
             if result != KERN_SUCCESS {
                 return Err(result);
             }
+
+            let io_iterator_t = io_iterator_t.assume_init();
 
             let mut v: Vec<Self> = Vec::new();
 


### PR DESCRIPTION
Hi, here's a patch to remove a deprecation warning when compiling io-kit.

The deprecation rational is here, if interested: https://doc.rust-lang.org/std/mem/fn.uninitialized.html
