### PR TITLE
Add parent() and children() to TIOObject

### DIFF
--- a/io-kit-sys/src/lib.rs
+++ b/io-kit-sys/src/lib.rs
@@ -404,14 +404,14 @@ pub const kIORegistryIterateParents: u32 = 0x00000002;
 extern "C" {
     pub fn IORegistryCreateIterator(
         masterPort: mach_port_t,
-        plane: *mut c_char,
+        plane: *const c_char,
         options: IOOptionBits,
         iterator: *mut io_iterator_t,
     ) -> kern_return_t;
 
     pub fn IORegistryEntryCreateIterator(
         entry: io_registry_entry_t,
-        plane: *mut c_char,
+        plane: *const c_char,
         options: IOOptionBits,
         iterator: *mut io_iterator_t,
     ) -> kern_return_t;
@@ -430,23 +430,23 @@ extern "C" {
 
     pub fn IORegistryEntryGetNameInPlane(
         entry: io_registry_entry_t,
-        plane: *mut c_char,
+        plane: *const c_char,
         name: *mut c_char,
     ) -> kern_return_t;
 
     pub fn IORegistryEntryGetLocationInPlane(
         entry: io_registry_entry_t,
-        plane: *mut c_char,
+        plane: *const c_char,
         location: *mut c_char,
     ) -> kern_return_t;
 
     pub fn IORegistryEntryGetPath(
         entry: io_registry_entry_t,
-        plane: *mut c_char,
+        plane: *const c_char,
         path: *mut c_char,
     ) -> kern_return_t;
 
-    pub fn IORegistryEntryCopyPath(entry: io_registry_entry_t, plane: *mut c_char) -> CFStringRef;
+    pub fn IORegistryEntryCopyPath(entry: io_registry_entry_t, plane: *const c_char) -> CFStringRef;
 
     pub fn IORegistryEntryGetRegistryEntryID(
         entry: io_registry_entry_t,
@@ -469,7 +469,7 @@ extern "C" {
 
     pub fn IORegistryEntrySearchCFProperty(
         entry: io_registry_entry_t,
-        plane: *mut c_char,
+        plane: *const c_char,
         key: CFStringRef,
         allocator: CFAllocatorRef,
         options: IOOptionBits,
@@ -499,29 +499,29 @@ extern "C" {
 
     pub fn IORegistryEntryGetChildIterator(
         entry: io_registry_entry_t,
-        plane: *mut c_char,
+        plane: *const c_char,
         iterator: *mut io_iterator_t,
     ) -> kern_return_t;
 
     pub fn IORegistryEntryGetChildEntry(
         entry: io_registry_entry_t,
-        plane: *mut c_char,
+        plane: *const c_char,
         child: *mut io_registry_entry_t,
     ) -> kern_return_t;
 
     pub fn IORegistryEntryGetParentIterator(
         entry: io_registry_entry_t,
-        plane: *mut c_char,
+        plane: *const c_char,
         iterator: *mut io_iterator_t,
     ) -> kern_return_t;
 
     pub fn IORegistryEntryGetParentEntry(
         entry: io_registry_entry_t,
-        plane: *mut c_char,
+        plane: *const c_char,
         parent: *mut io_registry_entry_t,
     ) -> kern_return_t;
 
-    pub fn IORegistryEntryInPlane(entry: io_registry_entry_t, plane: *mut c_char) -> boolean_t;
+    pub fn IORegistryEntryInPlane(entry: io_registry_entry_t, plane: *const c_char) -> boolean_t;
 }
 
 // Matching dictionary creation helpers

--- a/io-kit/src/base.rs
+++ b/io-kit/src/base.rs
@@ -6,7 +6,7 @@ use std::os::raw::c_char;
 use core_foundation::base::TCFType;
 use core_foundation::dictionary::CFDictionary;
 use core_foundation::string::CFString;
-use io_kit_sys::types::{io_iterator_t, io_object_t, io_service_t};
+use io_kit_sys::types::{io_iterator_t, io_object_t, io_service_t, io_registry_entry_t};
 use io_kit_sys::*;
 use mach::kern_return::KERN_SUCCESS;
 
@@ -220,6 +220,34 @@ pub trait TIOObject<concrete_io_object_t> {
                 None
             } else {
                 Some(TCFType::wrap_under_get_rule(result))
+            }
+        }
+    }
+
+    fn parent(&self, plane: *const c_char) -> Result<IOService, i32> {
+        unsafe {
+            let mut parent = mem::MaybeUninit::<io_registry_entry_t>::uninit();
+
+            let result = IORegistryEntryGetParentEntry(self.as_io_object_t(), plane, parent.as_mut_ptr());
+
+            if result == KERN_SUCCESS {
+                Ok(IOService(parent.assume_init()))
+            } else {
+                Err(result)
+            }
+        }
+    }
+
+    fn children(&self, plane: *const c_char) -> Result<IOIterator, i32> {
+        unsafe {
+            let mut it = mem::MaybeUninit::<io_iterator_t>::uninit();
+
+            let result = IORegistryEntryGetChildIterator(self.as_io_object_t(), plane, it.as_mut_ptr());
+
+            if result == KERN_SUCCESS {
+                Ok(IOIterator(it.assume_init()))
+            } else {
+                Err(result)
             }
         }
     }


### PR DESCRIPTION
Hi, this patch adds `parent()` and `children()` functions to the `TIOObject` trait.

I've been using the `io_kit` crate (as a git crate since it's not published) and it's been very nice to have some higher level wrappers on things. I needed these functions for my app but couldn't really implement them in my code since the `IOService` and `IOObject` structs have a private member.

The other pull requests I submitted are all independent except this one which relies on the `*const` change to `plane`. If that patch isn't acceptable this one could be changed to not include it.

Thanks for writing these crates! They made my life a lot easier. Are there any plans to ever publish the `io_kit` crate?